### PR TITLE
compilation errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,15 @@
         <configuration>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
when compiling with maven I got the following error:

```
$ mvn package
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Building Unnamed - com.rapportive:storm-json:jar:0.0.1
[INFO]    task-segment: [package]
[INFO] ------------------------------------------------------------------------
Downloading: http://repo1.maven.org/maven2/org/apache/maven/plugins/maven-javadoc-plugin/2.8/maven-javadoc-plugin-2.8.pom

Downloading: http://repo1.maven.org/maven2/org/apache/maven/plugins/maven-plugins/19/maven-plugins-19.pom

Downloading: http://repo1.maven.org/maven2/org/apache/maven/maven-parent/19/maven-parent-19.pom

Downloading: http://repo1.maven.org/maven2/org/apache/maven/plugins/maven-javadoc-plugin/2.8/maven-javadoc-plugin-2.8.jar

[INFO] [resources:resources {execution: default-resources}]
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /home/samus/dev/bigdata/storm-json/src/main/resources
[INFO] [compiler:compile {execution: default-compile}]
[INFO] Compiling 2 source files to /home/samus/dev/bigdata/storm-json/target/classes
[INFO] ------------------------------------------------------------------------
[ERROR] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Compilation failure

/home/samus/dev/bigdata/storm-json/src/main/java/com/rapportive/storm/scheme/SimpleJSONScheme.java:[63,5] annotations are not supported in -source 1.3
(use -source 5 or higher to enable annotations)
    @Override

/home/samus/dev/bigdata/storm-json/src/main/java/com/rapportive/storm/scheme/SimpleJSONScheme.java:[64,15] generics are not supported in -source 1.3
(use -source 5 or higher to enable generics)
    public List<Object> deserialize(byte[] bytes) {

/home/samus/dev/bigdata/storm-json/src/main/java/com/rapportive/storm/serializer/SimpleJSONSerializer.java:[32,59] generics are not supported in -source 1.3
(use -source 5 or higher to enable generics)
public class SimpleJSONSerializer implements ISerialization<Object> {

/home/samus/dev/bigdata/storm-json/src/main/java/com/rapportive/storm/serializer/SimpleJSONSerializer.java:[49,5] annotations are not supported in -source 1.3
(use -source 5 or higher to enable annotations)
    @SuppressWarnings("rawtypes")


[INFO] ------------------------------------------------------------------------
[INFO] For more information, run Maven with the -e switch
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 6 seconds
[INFO] Finished at: Thu Nov 24 15:18:49 UYST 2011
[INFO] Final Memory: 19M/169M
[INFO] ------------------------------------------------------------------------
```

this commit fixes that.
